### PR TITLE
add `trim()` method and some properties public

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,8 @@ import * as fs from 'fs'
 import { readPgmSync } from 'node-pgm'
 const buffer = fs.readFileSync('myimage.pgm')
 const pgm = readPgmSync(buffer)
-```
-
-To get the image header, use the getHeader function:
-
-```js
-const header = pgm.getHeader()
-console.log(header.width)
-console.log(header.height)
+console.log(pgm.width)
+console.log(pgm.height)
 ```
 
 To write a PGM file, use the writePgmSync function:
@@ -59,6 +53,7 @@ To write a PGM file, use the writePgmSync function:
 ```js
 import * as fs from 'fs'
 import { writePgmSync } from 'node-pgm'
+const pgm = new PGM(100, 100)
 const buffer = writePgmSync(pgm);
 fs.writeFileSync('newimage.pgm', buffer);
 ```
@@ -72,19 +67,18 @@ import * as fs from 'fs'
 import { readPgmSync, writePgmSync } from 'node-pgm'
 
 // read
-const file = fs.readFileSync('src.pgm')
+const file = fs.readFileSync('tests/files/gimp_binary.pgm')
 const pgm = readPgmSync(file)
 // invert the colors
-const w = meta.width; const h = meta.height
-for (let y = 0; y < h; y++) {
-  for (let x = 0; x < w; x++) {
-    const i = y * w + x
+for (let y = 0; y < pgm.height; y++) {
+  for (let x = 0; x < pgm.width; x++) {
+    const i = y * pgm.width + x
     const c = 255 - pgm.data.readUInt8(i)
     pgm.data.writeUInt8(c, i)
   }
 }
 // change descriptor from P5 to P2
-pgm.setDescriptor('P2')
+pgm.descriptor = 'P2'
 
 // save
 const buf = writePgmSync(pgm)
@@ -96,9 +90,25 @@ fs.writeFileSync('out.pgm', buf)
 ### `PGM` Class
 Class for creating PGM.
 
-- `constructor(width: number, height: number)` - Creates a new PGM instance with the specified width and height.
-- `setDescriptor(descriptor: string)` - Sets the descriptor for the PGM instance ('P5' or 'P2').
-- `getHeader(): Object` - Gets the header for the PGM instance, including the width, height, descriptor, comment, and maximum gray value.
+#### Constructor
+
+##### PGM(width, height)
+
+Creates a new PGM instance with the specified width and height.
+
+#### Properties
+
+- `width` (number): The width of the image.
+- `height` (number): The height of the image.
+- `comment` (string): The comment associated with the image.
+- `descriptor` (string): The descriptor of the PGM file. Default value is 'P5'.
+- `maxValue` (number): The maximum pixel value. Default value is 255.
+- `data` (Buffer): The pixel data of the image stored in a Buffer object.
+
+#### Methods
+
+##### trim(x, y, width, height)
+Trims the image to the specified dimensions and position.
 
 ### `readPgmSync(buffer: Buffer): PGM`
 Take a PGM format buffer and return a PGM object.

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -19,33 +19,30 @@ describe('pgm', () => {
       const file = fs.readFileSync(srcDir + 'map_saver.pgm')
       const pgm = readPgmSync(file)
       assert.instanceOf(pgm, PGM)
-      const meta = pgm.getHeader()
-      assert.equal(meta.descriptor, 'P5')
-      assert.equal(meta.comment, '# CREATOR: map_saver.cpp 0.050 m/pix')
-      assert.equal(meta.width, 4000)
-      assert.equal(meta.height, 4000)
+      assert.equal(pgm.descriptor, 'P5')
+      assert.equal(pgm.comment, '# CREATOR: map_saver.cpp 0.050 m/pix')
+      assert.equal(pgm.width, 4000)
+      assert.equal(pgm.height, 4000)
     })
 
     it('read gimp binary PGM', () => {
       const file = fs.readFileSync(srcDir + 'gimp_binary.pgm')
       const pgm = readPgmSync(file)
       assert.instanceOf(pgm, PGM)
-      const meta = pgm.getHeader()
-      assert.equal(meta.descriptor, 'P5')
-      assert.equal(meta.comment, '# Created by GIMP version 2.10.34 PNM plug-in')
-      assert.equal(meta.width, 480)
-      assert.equal(meta.height, 320)
+      assert.equal(pgm.descriptor, 'P5')
+      assert.equal(pgm.comment, '# Created by GIMP version 2.10.34 PNM plug-in')
+      assert.equal(pgm.width, 480)
+      assert.equal(pgm.height, 320)
     })
 
     it('read gimp ascii PGM', () => {
       const file = fs.readFileSync(srcDir + 'gimp_ascii.pgm')
       const pgm = readPgmSync(file)
       assert.instanceOf(pgm, PGM)
-      const meta = pgm.getHeader()
-      assert.equal(meta.descriptor, 'P2')
-      assert.equal(meta.comment, '# Created by GIMP version 2.10.34 PNM plug-in')
-      assert.equal(meta.width, 480)
-      assert.equal(meta.height, 320)
+      assert.equal(pgm.descriptor, 'P2')
+      assert.equal(pgm.comment, '# Created by GIMP version 2.10.34 PNM plug-in')
+      assert.equal(pgm.width, 480)
+      assert.equal(pgm.height, 320)
     })
 
     it('read incorrect size format PGM', () => {
@@ -75,26 +72,24 @@ describe('pgm', () => {
       fs.writeFileSync(destDir + '/output_binary.pgm', buf)
       // read
       const pgm2 = readPgmSync(buf)
-      const meta = pgm2.getHeader()
-      assert.equal(meta.descriptor, 'P5')
-      assert.equal(meta.comment, '')
-      assert.equal(meta.width, 240)
-      assert.equal(meta.height, 360)
+      assert.equal(pgm2.descriptor, 'P5')
+      assert.equal(pgm2.comment, '')
+      assert.equal(pgm2.width, 240)
+      assert.equal(pgm2.height, 360)
     })
     it('new ascii PGM', () => {
       const w = 480; const h = 120
       const pgm = new PGM(w, h)
       makeData(pgm)
-      pgm.setDescriptor('P2')
+      pgm.descriptor = 'P2'
       const buf = writePgmSync(pgm)
       fs.writeFileSync(destDir + '/output_ascii.pgm', buf)
       // read
       const pgm2 = readPgmSync(buf)
-      const meta = pgm2.getHeader()
-      assert.equal(meta.descriptor, 'P2')
-      assert.equal(meta.comment, '')
-      assert.equal(meta.width, 480)
-      assert.equal(meta.height, 120)
+      assert.equal(pgm2.descriptor, 'P2')
+      assert.equal(pgm2.comment, '')
+      assert.equal(pgm2.width, 480)
+      assert.equal(pgm2.height, 120)
     })
   })
 
@@ -102,7 +97,7 @@ describe('pgm', () => {
     it('P5 to P2', () => {
       const file = fs.readFileSync(srcDir + 'gimp_binary.pgm')
       const pgm = readPgmSync(file)
-      pgm.setDescriptor('P2')
+      pgm.descriptor = 'P2'
       const buf = writePgmSync(pgm)
       const srcBuf = fs.readFileSync(srcDir + 'gimp_ascii.pgm')
       assert.isTrue(buf.equals(srcBuf))
@@ -110,7 +105,7 @@ describe('pgm', () => {
     it('P2 to P5', () => {
       const file = fs.readFileSync(srcDir + 'gimp_ascii.pgm')
       const pgm = readPgmSync(file)
-      pgm.setDescriptor('P5')
+      pgm.descriptor = 'P5'
       const buf = writePgmSync(pgm)
       const srcBuf = fs.readFileSync(srcDir + 'gimp_binary.pgm')
       assert.isTrue(buf.equals(srcBuf))
@@ -118,7 +113,10 @@ describe('pgm', () => {
     it('set unsupported descriptor', () => {
       const file = fs.readFileSync(srcDir + 'gimp_ascii.pgm')
       const pgm = readPgmSync(file)
-      expect(() => pgm.setDescriptor('P3'))
+      expect(() => {
+        pgm.descriptor = 'P3'
+        writePgmSync(pgm)
+      })
         .to.throw(Error, 'unsupported descriptor: P3')
     })
   })
@@ -128,11 +126,10 @@ describe('pgm', () => {
       const file = fs.readFileSync(srcDir + 'multiline_comment.pgm')
       const pgm = readPgmSync(file)
       assert.instanceOf(pgm, PGM)
-      const meta = pgm.getHeader()
-      assert.equal(meta.descriptor, 'P5')
-      assert.equal(meta.comment, '# test comment\n# CREATOR: map_saver.cpp\n# test comment\n# test comment\n# test comment')
-      assert.equal(meta.width, 500)
-      assert.equal(meta.height, 360)
+      assert.equal(pgm.descriptor, 'P5')
+      assert.equal(pgm.comment, '# test comment\n# CREATOR: map_saver.cpp\n# test comment\n# test comment\n# test comment')
+      assert.equal(pgm.width, 500)
+      assert.equal(pgm.height, 360)
     })
     it('read and write binary PGM', () => {
       const file = fs.readFileSync(srcDir + 'multiline_comment.pgm')
@@ -141,12 +138,37 @@ describe('pgm', () => {
       fs.writeFileSync(destDir + '/output_multiline_comment.pgm', buf)
     })
   })
+
+  describe('change size', () => {
+    it('expand', () => {
+      const file = fs.readFileSync(srcDir + 'gimp_binary.pgm')
+      const pgm = readPgmSync(file)
+      pgm.width += 200
+      pgm.height += 400
+      const buf = writePgmSync(pgm)
+      fs.writeFileSync(destDir + '/output_expand.pgm', buf)
+    })
+    it('cut', () => {
+      const file = fs.readFileSync(srcDir + 'gimp_binary.pgm')
+      const pgm = readPgmSync(file)
+      pgm.width -= 100
+      pgm.height -= 50
+      const buf = writePgmSync(pgm)
+      fs.writeFileSync(destDir + '/output_cut.pgm', buf)
+    })
+    it('trim', () => {
+      const file = fs.readFileSync(srcDir + 'gimp_binary.pgm')
+      const pgm = readPgmSync(file)
+      pgm.trim(50, 100, 100, 80)
+      const buf = writePgmSync(pgm)
+      fs.writeFileSync(destDir + '/output_trim.pgm', buf)
+    })
+  })
 })
 
 function makeData (pgm) {
-  const header = pgm.getHeader()
-  const w = header.width
-  const h = header.height
+  const w = pgm.width
+  const h = pgm.height
   for (let y = 0; y < h; y++) {
     for (let x = 0; x < w; x++) {
       const c = Math.floor(x / w * y / h * 255)


### PR DESCRIPTION
## Proposed Changes

### New Feature

- add trim() method to PGM class. It allows trimming within the specified range.
- for convenience, made the properties width, height, descriptor, and maxValue of PGM class public.

When modified, the following processing will be performed during saving:
width and height: The size will be adjusted.
descriptor: Validation check will be performed.

maxValue is modifiable, but the behavior is not supported if the value is not 255.

### Breaking Change
- remove the setDescriptor() and getHeader() methods from PGM class.